### PR TITLE
Rename LESS to Less

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zed-less
 
-LESS language support for [Zed](https://zed.dev).
+[Less](https://lesscss.org/) language support for [Zed](https://zed.dev).
 
 ## Features
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "less"
-name = "LESS"
-description = "LESS language support"
+name = "Less"
+description = "Less language support"
 version = "0.1.0"
 schema_version = 1
 authors = ["jimliang <769925821@qq.com>"]
@@ -11,5 +11,5 @@ repository = "https://github.com/jimliang/tree-sitter-less"
 commit = "307541e7b4d9d890a0d85bd9acf7da777d26d323"
 
 [language_servers.less-language-server]
-name = "LESS Language Server"
-language = "LESS"
+name = "Less Language Server"
+language = "Less"

--- a/languages/less/config.toml
+++ b/languages/less/config.toml
@@ -1,4 +1,4 @@
-name = "LESS"
+name = "Less"
 grammar = "less"
 path_suffixes = ["less"]
 block_comment = ["/* ", " */"]

--- a/src/less.rs
+++ b/src/less.rs
@@ -5,11 +5,11 @@ const SERVER_PATH: &str =
     "node_modules/vscode-langservers-extracted/bin/vscode-css-language-server";
 const PACKAGE_NAME: &str = "vscode-langservers-extracted";
 
-pub struct LESSExtension {
+pub struct LessExtension {
     did_find_server: bool,
 }
 
-impl LESSExtension {
+impl LessExtension {
     fn server_exists(&self) -> bool {
         fs::metadata(SERVER_PATH).map_or(false, |stat| stat.is_file())
     }
@@ -55,7 +55,7 @@ impl LESSExtension {
     }
 }
 
-impl zed::Extension for LESSExtension {
+impl zed::Extension for LessExtension {
     fn new() -> Self {
         Self {
             did_find_server: false,
@@ -83,4 +83,4 @@ impl zed::Extension for LESSExtension {
     }
 }
 
-zed::register_extension!(LESSExtension);
+zed::register_extension!(LessExtension);


### PR DESCRIPTION
Hey! I noticed that this extension follows the common misconception that it’s LESS and SASS, not Less and Sass (but SCSS). I hope you will consider accepting these changes.

What it does:

- Renames LESS to Less, the official case for the language name, [see the website](https://lesscss.org/about/)
- Links to https://lesscss.org/ website from the readme

Let me know if I went too far by renaming `LESSExtension` to `LessExtension` in the source code, bit it seemed fair 😬

Thanks!