### PR TITLE
feat: add outline support

### DIFF
--- a/languages/less/outline.scm
+++ b/languages/less/outline.scm
@@ -1,0 +1,90 @@
+;; Less outline
+;; === Comments as annotations (optional)
+(comment) @annotation
+(js_comment) @annotation
+
+;; ===  base cass
+(stylesheet
+    (import_statement
+        "@import" @context
+        ((string_value) @name)) @item)
+
+(rule_set
+    (selectors
+      .
+      (_) @name
+      ("," @name (_) @name)*
+    )) @item
+
+(media_statement
+    "@media" @context
+    (_) @name
+    (block)
+) @item
+
+
+;; === Import statements: @import "xxx.less" / @import url("xxx.css")
+(import_statement
+  "@import" @context
+  (string_value) @name
+) @item
+
+(import_statement
+  "@import" @context
+  (call_expression
+    (function_name) @context
+    (arguments (string_value) @name)
+  )
+) @item
+
+;; === Rulesets: .a, #b { ... } (supports nested selectors)
+(rule_set
+  (selectors
+    (class_selector (class_name) @name)
+    (id_selector (id_name) @name)
+    (descendant_selector
+      (class_selector (class_name) @name)
+      (id_selector (id_name) @name)
+    )*
+  )
+) @item
+
+;; === Supports queries: @supports ... { ... }
+(supports_statement
+  "@supports" @context
+  (feature_query (feature_name) @name (plain_value) @context)
+  (block)
+) @item
+
+;; === Keyframes: @keyframes spin { ... }
+(keyframes_statement
+  "@keyframes" @context
+  (keyframes_name) @name
+  (keyframe_block_list)
+) @item
+
+;; === Mixin definitions: .mixin(...) { ... }
+(mixin_definition
+  (class_name) @name
+  (parameters) @context
+) @item
+
+;; === Plugin statements: @plugin "xxx" / @plugin grid
+(plugin_statement
+  "@plugin" @context
+  (string_value) @name
+) @item
+
+;; === Each statements: each(@colors, { ... })
+(each_statement
+  "each" @context
+  (variable) @name
+  (block)
+) @item
+
+;; 9. Variable declarations: @var: value;
+(declaration
+  (property_name) @name
+  ; _ @context
+  (#match? @name "^@")
+) @item

--- a/languages/less/outline.scm
+++ b/languages/less/outline.scm
@@ -22,21 +22,6 @@
     (block)
 ) @item
 
-
-;; === Import statements: @import "xxx.less" / @import url("xxx.css")
-(import_statement
-  "@import" @context
-  (string_value) @name
-) @item
-
-(import_statement
-  "@import" @context
-  (call_expression
-    (function_name) @context
-    (arguments (string_value) @name)
-  )
-) @item
-
 ;; === Rulesets: .a, #b { ... } (supports nested selectors)
 (rule_set
   (selectors
@@ -86,5 +71,5 @@
 (declaration
   (property_name) @name
   ; _ @context
-  (#match? @name "^@")
+  (#match? @name "^@|^--")
 ) @item


### PR DESCRIPTION
Add support for outline.scm.

Effect
<img width="2218" height="1570" alt="image" src="https://github.com/user-attachments/assets/558f8b57-c3b5-41d2-a223-c95e26a8d0ab" />

Then symbol search called


<img width="1238" height="1610" alt="image" src="https://github.com/user-attachments/assets/ecba46ff-a426-4e83-9e71-90fc110d3674" />


Currently tested with Less file

```less
// Imports
@import "base.less";
@import url("reset.css");

// Plugins
@plugin "less-plugin-inline-urls";
@plugin grid;

// Variables (top-level)
@primary-color: #0aa;
@spacing: calc(10px + 2);
@font-name: "Inter", sans-serif;

:root{
  --primary-color: #0aa;
  --spacing: calc(10px + 2);
  --font-name: "Inter", sans-serif;
}

// Mixin definition
.mixin(@c, @p) {
  color: @c;
  padding: @p;
}

// Ruleset with nested selectors and variable usage
.body, #app .container {
  .test {
    &::after {
      content: "";
    }
  }

  // property merge (should NOT be treated as variable in outline)
  background+_: url("/img/a.png");
}

// Media
@media screen and (min-width: 600px) {
  .grid {
    gap: @spacing;
    .mixin(#333, 12px);
  }
}

// Supports
@supports (display: grid) {
  .supports-grid {
    display: grid;
    .supports-grid{
      red: '#ff00'
    }
  }
}

// Keyframes
@keyframes spin {
  from { transform: rotate(0deg); }
  to { transform: rotate(360deg); }
}

// Block with last_declaration variable (no semicolon)
.wrapper {
  color: red;
  @last-no-semi: 10px
}

// Less each() built-in (function-style)
each(@colors, {
  .@{value}-text { color: @value; }
});


.test{
  @color01: #fff;
  @color02: #fff;
}
// Comments
// single-line comment
/* block comment */


```

